### PR TITLE
Adding support for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,13 +6,19 @@ set(PROJECT_BRIEF "A cross-platform implementation of a WebVTT parser written in
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-SET(GCC_COVERAGE_COMPILE_FLAGS "-Wno-narrowing")
+if (NOT MSVC)
+  SET(GCC_COVERAGE_COMPILE_FLAGS "-Wno-narrowing")
+endif (NOT MSVC)
 SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS}")
 
 add_definitions(-DWEBVTT_BUILD_LIBRARY)
+set(-DWEBVTT_BUILD_LIBRARY 0)
 if (BUILD_LIBRARY)
   set(-DWEBVTT_BUILD_LIBRARY 1)
 endif (BUILD_LIBRARY)
 
 add_subdirectory("src")
-add_subdirectory("test")
+if (NOT MSVC)
+  # There are linking errors when building tests under MSVC right now.
+  add_subdirectory("test")
+endif (NOT MSVC)

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,16 @@
+﻿{
+  "configurations": [
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "-DBUILD_LIBRARY=1",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "variables": []
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Once built, the static library and include files are available at these location
 * Static library: `build/src/webvttxx/libwebvttxx.a`
 * Include: `include/webvttxx`
 
-### Building A dll on Windows (MinGW)
+### Building a .dll in Windows (MinGW)
 [CMake](https://cmake.org/) is also used on Windows for running the builds and tests, but it's recommended to use [MSYS2](https://www.msys2.org/) to create the Mingw64 build environment.
 
 When using CMake, it's recommended that builds take place outside of the main project source, such as in a `build` directory.
@@ -81,6 +81,15 @@ make all test
 # run the test executable
 test/unit/unittests
 ```
+
+### Building in Microsoft Visual Studio 10 with UWP
+1. Download or clone this repository.
+2. Ensure that [Visual Studio Installer](https://docs.microsoft.com/en-us/visualstudio/install/install-visual-studio?view=vs-2019) has installed the following Workloads:
+  * Desktop development with C++
+  * Universal Windows Platform development
+3. Open Microsoft Visual Studio, and File -> Open -> CMake...
+4. Navigate to this project's CMakeLists.txt in the root project directory. This will import the Webvtt project. This project's Visual Studio settings are in CMakeSettings.json. It's configured already to build libwebvtt.dll.
+5. Select Build -> Build All. This will produce a .lib and a .dll file in out/build/x64-Debug/src/webvtt, and some .lib files in the other src/ directories.
 
 ## Versioning
 

--- a/src/webvtt/CMakeLists.txt
+++ b/src/webvtt/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
 add_definitions("-DACSDK_LOG_MODULE=captionslib")
 
-if (BUILD_LIBRARY AND WIN32 OR WIN64)
+if (BUILD_LIBRARY AND (WIN32 OR WIN64 OR MSVC))
   add_library(libwebvtt SHARED
           alloc.c
           cue.c
@@ -12,7 +12,7 @@ if (BUILD_LIBRARY AND WIN32 OR WIN64)
           node.c
           parser.c
           string.c)
-else (BUILD_LIBRARY AND WIN32 OR WIN64)
+else (BUILD_LIBRARY AND (WIN32 OR WIN64 OR MSVC))
   add_library(libwebvtt STATIC
           alloc.c
           cue.c
@@ -22,7 +22,7 @@ else (BUILD_LIBRARY AND WIN32 OR WIN64)
           node.c
           parser.c
           string.c)
-endif (BUILD_LIBRARY AND WIN32 OR WIN64)
+endif (BUILD_LIBRARY AND (WIN32 OR WIN64 OR MSVC))
 
 target_include_directories(libwebvtt PUBLIC
         "${libwebvtt_SOURCE_DIR}"

--- a/src/webvttxx/CMakeLists.txt
+++ b/src/webvttxx/CMakeLists.txt
@@ -1,14 +1,14 @@
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
-if (BUILD_LIBRARY AND WIN32 OR WIN64)
+if (BUILD_LIBRARY AND (WIN32 OR WIN64 OR MSVC))
   add_library(libwebvttxx OBJECT
           abstract_parser.cpp
           file_parser.cpp)
-else (BUILD_LIBRARY AND WIN32 OR WIN64)
+else (BUILD_LIBRARY AND (WIN32 OR WIN64 OR MSVC))
   add_library(libwebvttxx STATIC
           abstract_parser.cpp
           file_parser.cpp)
-endif (BUILD_LIBRARY AND WIN32 OR WIN64)
+endif (BUILD_LIBRARY AND (WIN32 OR WIN64 OR MSVC))
 
 target_include_directories(libwebvttxx PUBLIC
         "${PROJECT_SOURCE_DIR}/include")


### PR DESCRIPTION
Adding support for MS Visual Studio, with instructions on how to create libwebvtt.dll. Still needs to correct a linking error for the unit tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
